### PR TITLE
add icon to contribution

### DIFF
--- a/vss-extension.json
+++ b/vss-extension.json
@@ -53,7 +53,13 @@
             "properties": {
                 "name": "Organize Repos",
                 "order": 99,
-                "uri": "directory-categorization.html"
+                "uri": "directory-categorization.html",
+				"iconAsset": "Magenic.ado-source-cat/icon.png",
+				"_sharedData": {
+					"assets": [
+						"Magenic.ado-source-cat/icon.png"
+						]
+				}
             },
             "restrictedTo": [
                 "member"
@@ -107,6 +113,10 @@
             "addressable": true
         },
         {
+			"path": "icon.png",
+			"addressabel": true
+		},
+		{
             "path": "images"
         },
         {


### PR DESCRIPTION
Adding a reference to the icon.png file in the **contributions** section of the vss-extension.json to correct the hub icon.

![image](https://user-images.githubusercontent.com/5280734/61821939-0a812b00-ae1e-11e9-9d62-af82ddf726b1.png)
