### PR TITLE
order repo descriptions

### DIFF
--- a/scripts/repositorytree.js
+++ b/scripts/repositorytree.js
@@ -291,7 +291,7 @@ function loadRepositoryCombo(container, valueLabel, validate) {
     repositories.forEach(element => {
       repositoryDescriptions.push(element.name);
     });
-
+    repositoryDescriptions.sort();
 
     var options = {
       width: "400px",


### PR DESCRIPTION
Before setting the repositoryDescriptions array as the source for the combo control, call `.sort();`